### PR TITLE
Support color (%c) inputs in the custom block spec editor

### DIFF
--- a/src/blocks/BlockArg.as
+++ b/src/blocks/BlockArg.as
@@ -60,6 +60,7 @@ public class BlockArg extends Sprite {
 	public var menuName:String;
 
 	private var menuIcon:Shape;
+	private var colorIcon:Shape;
 
 	// BlockArg types:
 	//	b - boolean (pointed)
@@ -69,7 +70,7 @@ public class BlockArg extends Sprite {
 	//	n - number (rounded)
 	//	s - string (rectangular)
 	//	none of the above - custom subclass of BlockArg
-	public function BlockArg(type:String, color:int, editable:Boolean = false, menuName:String = '') {
+	public function BlockArg(type:String, color:int, editable:Boolean = false, menuName:String = '', shouldHaveColorIcon:Boolean = false) {
 		this.type = type;
 
 		if (color == -1) { // copy for clone; omit graphics
@@ -125,6 +126,17 @@ public class BlockArg extends Sprite {
 			g.endFill();
 			menuIcon.y = 5;
 			addChild(menuIcon);
+		}
+
+		if (shouldHaveColorIcon) { // add a color icon
+			colorIcon = new Shape();
+			var g:Graphics = colorIcon.graphics;
+			g.beginFill(0x632D99, 1);
+			g.drawRoundRect(0, 0, 5, 5, 5);
+			g.endFill();
+			colorIcon.x = 5;
+			colorIcon.y = 5;
+			addChild(colorIcon);
 		}
 
 		if (editable || numberType || (type == 'm')) { // add a string field
@@ -227,9 +239,10 @@ public class BlockArg extends Sprite {
 		// fix layout:
 		var padding:int = (type == 'n') ? 3 : 0;
 		if (type == 'b') padding = 8;
-		if (menuIcon != null) padding = (type == 'd') ? 10 : 13;
+		if (menuIcon != null || colorIcon != null) padding = (type == 'd') ? 10 : 13;
 		var w:int = Math.max(14, field.textWidth + 6 + padding);
 		if (menuIcon) menuIcon.x = w - menuIcon.width - 3;
+		if (colorIcon) colorIcon.x = w - colorIcon.width - 5;
 		base.setWidth(w);
 		base.redraw();
 		if (parent is Block) Block(parent).fixExpressionLayout();

--- a/src/ui/ProcedureSpecEditor.as
+++ b/src/ui/ProcedureSpecEditor.as
@@ -83,6 +83,7 @@ public class ProcedureSpecEditor extends Sprite {
 			'Add number input:',
 			'Add string input:',
 			'Add boolean input:',
+			'Add color input:',
 			'Add label text:',
 			'text',
 		];
@@ -117,6 +118,7 @@ public class ProcedureSpecEditor extends Sprite {
 				if (argSpec == 'b') arg = makeBooleanArg();
 				if (argSpec == 'n') arg = makeNumberArg();
 				if (argSpec == 's') arg = makeStringArg();
+				if (argSpec == 'c') arg = makeColorArg();
 				if (arg) {
 					arg.setArgValue(inputNames[i++]);
 					addElement(arg);
@@ -179,12 +181,14 @@ public class ProcedureSpecEditor extends Sprite {
 			makeLabel('Add number input:', 14),
 			makeLabel('Add string input:', 14),
 			makeLabel('Add boolean input:', 14),
+			makeLabel('Add color input:', 14),
 			makeLabel('Add label text:', 14)
 		];
 		buttons = [
 			new Button('', function():void { appendObj(makeNumberArg()) }),
 			new Button('', function():void { appendObj(makeStringArg()) }),
 			new Button('', function():void { appendObj(makeBooleanArg()) }),
+			new Button('', function():void { appendObj(makeColorArg()) }),
 			new Button(Translator.map('text'), function():void { appendObj(makeTextField('')) })
 		];
 
@@ -201,6 +205,10 @@ public class ProcedureSpecEditor extends Sprite {
 		var icon:BlockShape = new BlockShape(BlockShape.BooleanShape, lightGray);
 		icon.setWidthAndTopHeight(25, 14, true);
 		buttons[2].setIcon(icon);
+
+		icon = new BlockShape(BlockShape.RectShape, lightGray);
+		icon.setWidthAndTopHeight(14, 14, true);
+		buttons[3].setIcon(icon);
 
 		for each (var label:TextField in buttonLabels) addChild(label);
 		for each (var b:Button in buttons) addChild(b);
@@ -277,6 +285,12 @@ public class ProcedureSpecEditor extends Sprite {
 	private function makeStringArg():BlockArg {
 		var result:BlockArg = new BlockArg('s', 0xFFFFFF, true);
 		result.setArgValue(unusedArgName('string'));
+		return result;
+	}
+
+	private function makeColorArg():BlockArg {
+		var result:BlockArg = new BlockArg('c', 0xFFFFFF, true);
+		result.setArgValue(unusedArgName('color'));
 		return result;
 	}
 

--- a/src/ui/ProcedureSpecEditor.as
+++ b/src/ui/ProcedureSpecEditor.as
@@ -27,6 +27,7 @@ package ui {
 	import uiwidgets.*;
 	import util.*;
 	import translation.Translator;
+	import util.Color;
 
 public class ProcedureSpecEditor extends Sprite {
 
@@ -157,6 +158,7 @@ public class ProcedureSpecEditor extends Sprite {
 				if (arg.type == 'b') v = false;
 				if (arg.type == 'n') v = 1;
 				if (arg.type == 's') v = '';
+				if (arg.type == 'c') v = Color.random();
 				result.push(v);
 			}
 		}
@@ -207,7 +209,7 @@ public class ProcedureSpecEditor extends Sprite {
 		buttons[2].setIcon(icon);
 
 		icon = new BlockShape(BlockShape.RectShape, lightGray);
-		icon.setWidthAndTopHeight(14, 14, true);
+		icon.setWidthAndTopHeight(16, 16, true);
 		buttons[3].setIcon(icon);
 
 		for each (var label:TextField in buttonLabels) addChild(label);
@@ -289,7 +291,7 @@ public class ProcedureSpecEditor extends Sprite {
 	}
 
 	private function makeColorArg():BlockArg {
-		var result:BlockArg = new BlockArg('c', 0xFFFFFF, true);
+		var result:BlockArg = new BlockArg('c', 0xFFFFFF, true, '', true);
 		result.setArgValue(unusedArgName('color'));
 		return result;
 	}


### PR DESCRIPTION
<sup>I've played around with `%m.*` inputs but haven't got them to work as of yet.</sup>

![image](https://cloud.githubusercontent.com/assets/9429556/23082394/0fa2ffec-f551-11e6-89c6-d6c17bfb08f8.png)
![image](https://cloud.githubusercontent.com/assets/9429556/23082409/1a271a98-f551-11e6-8bec-9652ab1adb64.png)

This was already possible by editing the JSON so I figured it'd be worth adding - see #22.