### PR TITLE
Magic vars

### DIFF
--- a/src/scratch/PaletteBuilder.as
+++ b/src/scratch/PaletteBuilder.as
@@ -198,6 +198,12 @@ public class PaletteBuilder {
 
     function addBlocks(names:Array):void {
       for each (var n:String in names) {
+        if (n.indexOf(Specs.MAGIC_PROC_PREFIX) === 0) {
+          if (!(viewedScript && viewedScript.op === 'procDef' && viewedScript.spec.indexOf(Specs.MAGIC_PROC_PREFIX) === 0)) {
+            continue;
+          }
+        }
+
         addVariableCheckbox(n, getSpec === Specs.GET_LIST);
         addItem(new Block(n, 'r', catColor, getSpec), true);
       }


### PR DESCRIPTION
This PR makes variables whose names start with `MAGIC_PROC_PREFIX` not appear visible in the block palette, unless currently editing a "Scrap Library block" (or a custom block whose spec starts with `MAGIC_PROC_PREFIX`).

This is so that Scrap library blocks can use variables that won't interfere with normal user-defined variables (e.g. instead of `parse` they can use `$$SCRAP:parse`; `parse` may well be used by the user, `$$SCRAP:parse` is probably safer).